### PR TITLE
Implemented error catching on the fail-fast principle

### DIFF
--- a/@v2/run.sh
+++ b/@v2/run.sh
@@ -31,11 +31,15 @@ trace() {
     echo -e "::group::$2"
     echo -e "\e[32m› $1"
     eval "$1"
+    ERROR_CODE=$?
+    if [[ $ERROR_CODE -ne 0 ]]; then
+        exit $ERROR_CODE
+    fi
     echo "::endgroup::"
 }
 
-trace "sudo npm install -g @cloudbase/cli --loglevel=error | grep @cloudbase/cli@" "\e[34mDownload and install cloudbase cli"
+trace "sudo npm install -g @cloudbase/cli --loglevel=error" "\e[34mDownload and install cloudbase cli"
 
-trace "tcb login --apiKeyId "$SECRET_ID" --apiKey "$SECRET_KEY" | grep "登录"" "\e[34mLogin to cloudbase"
+trace "tcb login --apiKeyId "$SECRET_ID" --apiKey "$SECRET_KEY"" "\e[34mLogin to cloudbase"
 
 trace "tcb framework deploy -e "$ENV_ID"" "\e[36mDeploy to cloudbase"

--- a/@v2/run.sh
+++ b/@v2/run.sh
@@ -30,10 +30,8 @@ trace() {
     # Group inner steps
     echo -e "::group::$2"
     echo -e "\e[32m› $1"
-    eval "$1"
-    ERROR_CODE=$?
-    if [[ $ERROR_CODE -ne 0 ]]; then
-        exit $ERROR_CODE
+    if ! eval "$1" ; then
+        exit 1
     fi
     echo "::endgroup::"
 }

--- a/@v2/run.sh
+++ b/@v2/run.sh
@@ -36,7 +36,7 @@ trace() {
     echo "::endgroup::"
 }
 
-trace "sudo npm install -g @cloudbase/cli --loglevel=error" "\e[34mDownload and install cloudbase cli"
+trace "sudo npm install -g @cloudbase/cli --loglevel=error --no-fund --no-audit --no-progress --prefer-offline" "\e[34mDownload and install cloudbase cli"
 
 trace "tcb login --apiKeyId "$SECRET_ID" --apiKey "$SECRET_KEY"" "\e[34mLogin to cloudbase"
 


### PR DESCRIPTION
Hi maintainers,

目前我们有三个项目都集成了该Action实现CI/CD，感谢两位实现了这个Action 🎉

## Problem

我们在使用途中发现了一个问题，当`tcb`在执行中因为任何原因`exit`的时候，这个Action不会一起`exit`并告知repo owner这次Action执行失败。可以看[例子1](https://github.com/UCLCSSA/UCL-Freshers-Guide/runs/3342419938?check_suite_focus=true#step:3:39)和[例子2](https://github.com/UCLCSSA/UCL-Freshers-Guide/runs/3342360761?check_suite_focus=true#step:3:37)。还有其他自己例子因为在private repo中所以不便于展示，比如网络请求超时、部署失败和登陆失败等。

## Cause

Deep dive发现 `trace()`函数使用`eval`来解析执行命令，因此命令若`exit`不会触发整个workflow执行的fail

```shell
#
# Trace commands, print tips & description
# @param command The actual command to execute
# @param description Describe the purpose of the command, with ansi color
#
trace() {
    # Group inner steps
    echo -e "::group::$2"
    echo -e "\e[32m› $1"
    eval "$1"
    echo "::endgroup::"
}
```

`echo $?` 后发现`$1`的exit code符合期望表现

```shell
trace() {
    ...
    eval "$1"
    echo $?
    ...
}
```

## Solution

84ab593 中增加了错误处理机制去及时的`exit`这个Action，使得用户可以及时的通过邮件或者其他机制收到部署失败信息

## Notes

这是第一次提sh脚本的PR所以可能有实现的不是特别好的地方，而且因为上游`cloudbase/cli`的[GitHub repo](https://github.com/TencentCloudBase/cloudbase-cli)好像没有更新v1版本所以没法deep dive上游源码，还请大佬帮我测试一下

All the best,